### PR TITLE
Fix create_modified_index bug

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,102 @@
+import os
+import zlib
+
+import pytest
+
+import zran
+
+DFL_WBITS = -15
+ZLIB_WBITS = 15
+GZ_WBITS = 31
+
+
+@pytest.fixture(scope='module')
+def input_data():
+    slc_name = 'tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
+    iw3_vv_start, iw3_vv_stop = (35813, 862111605)
+    if not os.path.isfile(slc_name):
+        raise FileNotFoundError(f'{slc_name} must be present')
+
+    with open(slc_name, 'rb') as f:
+        f.seek(iw3_vv_start)
+        body = f.read(iw3_vv_stop - iw3_vv_start)
+    index = zran.Index.create_index(body, span=2**20)
+    golden = zlib.decompress(body, wbits=DFL_WBITS)
+
+    yield (body, golden, index)
+
+    del body
+    del golden
+    del index
+
+
+def create_compressed_data(uncompressed_data, wbits, start=None, stop=None):
+    compress_obj = zlib.compressobj(wbits=wbits)
+    compressed = compress_obj.compress(uncompressed_data)
+    compressed += compress_obj.flush()
+
+    if not start:
+        start = 0
+
+    if not stop:
+        stop = len(compressed)
+
+    return compressed[start:stop]
+
+
+@pytest.fixture(scope='module')
+def gz_points():
+    values = [
+        zran.Point(0, 1010, 0, b''),
+        zran.Point(200, 1110, 0, b''),
+        zran.Point(300, 1210, 0, b''),
+        zran.Point(400, 1310, 0, b''),
+    ]
+    return values
+
+
+@pytest.fixture(scope='module')
+def data():
+    out = os.urandom(2**22)
+    return out
+
+
+@pytest.fixture(scope='module')
+def compressed_gz_data_no_head(data):
+    compressed_data = create_compressed_data(data, GZ_WBITS, start=1562)
+    yield compressed_data
+    del compressed_data
+
+
+@pytest.fixture(scope='module')
+def compressed_gz_data_no_tail(data):
+    compressed_data = create_compressed_data(data, GZ_WBITS, stop=-1587)
+    yield compressed_data
+    del compressed_data
+
+
+@pytest.fixture(scope='module')
+def compressed_gz_data(data):
+    compressed_data = create_compressed_data(data, GZ_WBITS)
+    yield compressed_data
+    del compressed_data
+
+
+@pytest.fixture(scope='module')
+def compressed_dfl_data(data):
+    compressed_data = create_compressed_data(data, DFL_WBITS)
+    yield compressed_data
+    del compressed_data
+
+
+@pytest.fixture(scope='module')
+def compressed_zlib_data(data):
+    compressed_data = create_compressed_data(data, ZLIB_WBITS)
+    yield compressed_data
+    del compressed_data
+
+
+@pytest.fixture(scope='function')
+def compressed_file(request, compressed_gz_data, compressed_dfl_data, compressed_zlib_data):
+    filenames = {'gz': compressed_gz_data, 'dfl': compressed_dfl_data, 'zlib': compressed_zlib_data}
+    return filenames[request.param]

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -1,6 +1,4 @@
-import os
 import tempfile
-import zlib
 from collections import namedtuple
 
 import pytest
@@ -23,98 +21,6 @@ offset_list = [
     Offset(start=1042580895, stop=1191505395),
     Offset(start=1191505395, stop=1340429895),
 ]
-
-
-@pytest.fixture(scope='module')
-def input_data():
-    slc_name = 'tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
-    iw3_vv_start, iw3_vv_stop = (35813, 862111605)
-    if not os.path.isfile(slc_name):
-        raise FileNotFoundError(f'{slc_name} must be present')
-
-    with open(slc_name, 'rb') as f:
-        f.seek(iw3_vv_start)
-        body = f.read(iw3_vv_stop - iw3_vv_start)
-    index = zran.Index.create_index(body, span=2**20)
-    golden = zlib.decompress(body, wbits=DFL_WBITS)
-
-    yield (body, golden, index)
-
-    del body
-    del golden
-    del index
-
-
-def create_compressed_data(uncompressed_data, wbits, start=None, stop=None):
-    compress_obj = zlib.compressobj(wbits=wbits)
-    compressed = compress_obj.compress(uncompressed_data)
-    compressed += compress_obj.flush()
-
-    if not start:
-        start = 0
-
-    if not stop:
-        stop = len(compressed)
-
-    return compressed[start:stop]
-
-
-@pytest.fixture(scope='module')
-def gz_points():
-    values = [
-        zran.Point(0, 1010, 0, b''),
-        zran.Point(200, 1110, 0, b''),
-        zran.Point(300, 1210, 0, b''),
-        zran.Point(400, 1310, 0, b''),
-    ]
-    return values
-
-
-@pytest.fixture(scope='module')
-def data():
-    out = os.urandom(2**22)
-    return out
-
-
-@pytest.fixture(scope='module')
-def compressed_gz_data_no_head(data):
-    compressed_data = create_compressed_data(data, GZ_WBITS, start=1562)
-    yield compressed_data
-    del compressed_data
-
-
-@pytest.fixture(scope='module')
-def compressed_gz_data_no_tail(data):
-    compressed_data = create_compressed_data(data, GZ_WBITS, stop=-1587)
-    yield compressed_data
-    del compressed_data
-
-
-@pytest.fixture(scope='module')
-def compressed_gz_data(data):
-    compressed_data = create_compressed_data(data, GZ_WBITS)
-    yield compressed_data
-    del compressed_data
-
-
-@pytest.fixture(scope='module')
-def compressed_dfl_data(data):
-    compressed_data = create_compressed_data(data, DFL_WBITS)
-    yield compressed_data
-    del compressed_data
-
-
-@pytest.fixture(scope='module')
-def compressed_zlib_data(data):
-    compressed_data = create_compressed_data(data, ZLIB_WBITS)
-    yield compressed_data
-    del compressed_data
-
-
-@pytest.fixture(scope='function')
-def compressed_file(request, compressed_gz_data, compressed_dfl_data, compressed_zlib_data):
-    filenames = {'gz': compressed_gz_data, 'dfl': compressed_dfl_data, 'zlib': compressed_zlib_data}
-    return filenames[request.param]
 
 
 def test_create_index(compressed_gz_data):

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import zlib
+from collections import namedtuple
 
 import pytest
 
@@ -9,6 +10,39 @@ import zran
 DFL_WBITS = -15
 ZLIB_WBITS = 15
 GZ_WBITS = 31
+
+Offset = namedtuple('Offset', ['start', 'stop'])
+offset_list = [
+    Offset(start=109395, stop=149033895),
+    Offset(start=149033895, stop=297958395),
+    Offset(start=297958395, stop=446882895),
+    Offset(start=446882895, stop=595807395),
+    Offset(start=595807395, stop=744731895),
+    Offset(start=744731895, stop=893656395),
+    Offset(start=893656395, stop=1042580895),
+    Offset(start=1042580895, stop=1191505395),
+    Offset(start=1191505395, stop=1340429895),
+]
+
+
+@pytest.fixture(scope='module')
+def input_data():
+    slc_name = 'tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
+    iw3_vv_start, iw3_vv_stop = (35813, 862111605)
+    if not os.path.isfile(slc_name):
+        raise FileNotFoundError(f'{slc_name} must be present')
+
+    with open(slc_name, 'rb') as f:
+        f.seek(iw3_vv_start)
+        body = f.read(iw3_vv_stop - iw3_vv_start)
+    index = zran.Index.create_index(body, span=2**20)
+    golden = zlib.decompress(body, wbits=DFL_WBITS)
+
+    yield (body, golden, index)
+
+    del body
+    del golden
+    del index
 
 
 def create_compressed_data(uncompressed_data, wbits, start=None, stop=None):
@@ -165,31 +199,11 @@ def test_modify_index_and_decompress(start_index, stop_index, data, compressed_d
     assert data[start:stop] == test_data
 
 
-from collections import namedtuple
-Offset = namedtuple('Offset', ['start', 'stop'])
-offset_list = [Offset(start=109395, stop=149033895), Offset(start=149033895, stop=297958395)]
-
-
-@pytest.fixture(scope='module')
-def swath():
-    slc_name = 'tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
-    with open(slc_name, 'rb') as f:
-        f.seek(35813)
-        body = f.read(862111605 - 35813)
-    yield body
-    del body
-
-
+@pytest.mark.skip('Integration test. Only run if testing Sentinel-1 SLC burst compatibility')
 @pytest.mark.parametrize('burst', offset_list)
-def test_safe(burst, swath):
-
-    index = zran.Index.create_index(swath)
-
+def test_safe(burst, input_data):
+    swath, golden, index = input_data
     compressed_range, uncompressed_range, new_index = index.create_modified_index([burst.start], [burst.stop])
-    test_data = zran.decompress(
-        swath[compressed_range[0] : compressed_range[1]],
-        new_index,
-        burst.start - uncompressed_range[0],
-        burst.stop - burst.start,
-    )
-    assert True
+    data_subset = swath[compressed_range[0] : compressed_range[1]]
+    test_data = zran.decompress(data_subset, new_index, burst.start - uncompressed_range[0], burst.stop - burst.start)
+    assert golden[burst.start : burst.stop] == test_data


### PR DESCRIPTION
When modifying an index removes the first `Point`, and the new first `Point` has a `bits` values that is not 0, decompression fails. This can be corrected by adding a `Point` to the modified index before the true desired first `Point`. 