### PR TITLE
Add optimizations to reduce modified index size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5]
+### Added
+* Set the window info to all zeros for first point in first point.bits != 0 case. This decreased compressed index size
+* New default for `create_modified_index` is to remove the last stop point, since the final point represents the end of the data
+* Update testing to increase coverage of `create_modified_index` corner cases
+
 ## [0.0.4]
 ### Added
 * New information to the README.md concerning contributions and similar projects

--- a/src/zran/zranlib.pyx
+++ b/src/zran/zranlib.pyx
@@ -270,16 +270,24 @@ class Index:
 
         inloc_offset = desired_points[0].inloc - compressed_offsets[0]
         outloc_offset = desired_points[0].outloc
-        desired_points = [
-            Point(x.outloc - outloc_offset, x.inloc - inloc_offset, x.bits, x.window) for x in desired_points
-        ]
+
+        output_points = []
+        start_point_is_last_in_origional = start_index == len(compressed_offsets) - 1
+        for i, point in enumerate(desired_points):
+            last_point_in_new_index = i == len(desired_points) - 1
+            if last_point_in_new_index and not start_point_is_last_in_origional:
+                window = bytearray(WINDOW_LENGTH)
+            else:
+                window = point.window
+            new_point = Point(point.outloc - outloc_offset, point.inloc - inloc_offset, point.bits, window)
+            output_points.append(new_point)
 
         modified_index = Index(
             self.have,
             compressed_range[1] - compressed_range[0],
             uncompressed_range[1] - uncompressed_range[0],
-            len(desired_points),
-            desired_points,
+            len(output_points),
+            output_points,
         )
         return compressed_range, uncompressed_range, modified_index
 

--- a/src/zran/zranlib.pyx
+++ b/src/zran/zranlib.pyx
@@ -275,7 +275,9 @@ class Index:
         start_point_is_last_in_origional = start_index == len(compressed_offsets) - 1
         for i, point in enumerate(desired_points):
             last_point_in_new_index = i == len(desired_points) - 1
-            if last_point_in_new_index and not start_point_is_last_in_origional:
+            if i == 0:
+                window = bytearray(WINDOW_LENGTH)
+            elif last_point_in_new_index and not start_point_is_last_in_origional:
                 window = bytearray(WINDOW_LENGTH)
             else:
                 window = point.window

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import random
 import zlib
 
 import pytest
@@ -31,7 +32,7 @@ def input_data():
 
 
 def create_compressed_data(uncompressed_data, wbits, start=None, stop=None):
-    compress_obj = zlib.compressobj(wbits=wbits)
+    compress_obj = zlib.compressobj(wbits=wbits, level=9)
     compressed = compress_obj.compress(uncompressed_data)
     compressed += compress_obj.flush()
 
@@ -57,7 +58,10 @@ def gz_points():
 
 @pytest.fixture(scope='module')
 def data():
-    out = os.urandom(2**22)
+    # Can't use os.random directly because there needs to be some
+    # repitition in order for compression to be effective
+    words = [os.urandom(8) for _ in range(1000)]
+    out = b''.join([random.choice(words) for _ in range(524288)])
     return out
 
 

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -32,13 +32,13 @@ def test_create_index(compressed_gz_data):
     assert len(points[0].window) == 32768
 
 
-@pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
+# @pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
 def test_create_index_fail_head(data, compressed_gz_data_no_head):
     with pytest.raises(zran.ZranError, match='zran: compressed data error in input file'):
         zran.Index.create_index(compressed_gz_data_no_head)
 
 
-@pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
+# @pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
 def test_create_index_fail_tail(data, compressed_gz_data_no_tail):
     with pytest.raises(zran.ZranError, match='zran: input file ended prematurely'):
         zran.Index.create_index(compressed_gz_data_no_tail)
@@ -68,7 +68,7 @@ def test_decompress(data, compressed_file):
     assert data[start : start + length] == test_data
 
 
-@pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
+# @pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
 def test_decompress_fail(data, compressed_gz_data, compressed_gz_data_no_head):
     start = 100
     length = 1000
@@ -86,11 +86,41 @@ def test_get_closest_point():
     assert r2.outloc == 4
 
 
+def test_modify_index_and_beginning_decompress(data, compressed_dfl_data):
+    index = zran.Index.create_index(compressed_dfl_data, span=2**18)
+    start = 0
+    stop = 100
+
+    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    test_data = zran.decompress(
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]],
+        new_index,
+        start - uncompressed_range[0],
+        stop - start,
+    )
+    assert data[start:stop] == test_data
+
+
 @pytest.mark.parametrize('start_index,stop_index', ((0, 5), (4, 10), (9, -1)))
-def test_modify_index_and_decompress(start_index, stop_index, data, compressed_dfl_data):
+def test_modify_index_and_interior_decompress(start_index, stop_index, data, compressed_dfl_data):
     index = zran.Index.create_index(compressed_dfl_data, span=2**18)
     start = index.points[start_index].outloc + 100
     stop = index.points[stop_index].outloc + 100
+
+    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    test_data = zran.decompress(
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]],
+        new_index,
+        start - uncompressed_range[0],
+        stop - start,
+    )
+    assert data[start:stop] == test_data
+
+
+def test_modify_index_and_end_decompress(data, compressed_dfl_data):
+    index = zran.Index.create_index(compressed_dfl_data, span=2**18)
+    start = index.points[-1].outloc + 100
+    stop = len(data)
 
     compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
     test_data = zran.decompress(

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -108,6 +108,7 @@ def test_modify_index_and_interior_decompress(start_index, stop_index, data, com
     stop = index.points[stop_index].outloc + 100
 
     compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    breakpoint()
     test_data = zran.decompress(
         compressed_dfl_data[compressed_range[0] : compressed_range[1]],
         new_index,
@@ -128,6 +129,26 @@ def test_modify_index_and_end_decompress(data, compressed_dfl_data):
         new_index,
         start - uncompressed_range[0],
         stop - start,
+    )
+    assert data[start:stop] == test_data
+
+
+def test_index_and_read_late(data, compressed_dfl_data):
+    index = zran.Index.create_index(compressed_dfl_data, span=2**18)
+    with pytest.raises(ValueError, match='Offset and length specified would result in reading past the file bounds'):
+        zran.decompress(compressed_dfl_data, index, 0, len(data))
+
+
+def test_modify_index_and_read_late(data, compressed_dfl_data):
+    index = zran.Index.create_index(compressed_dfl_data, span=2**18)
+    start = index.points[5].outloc
+    stop = index.points[10].outloc
+
+    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    offset = start - uncompressed_range[0]
+    length = stop - start
+    test_data = zran.decompress(
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]], new_index, offset, length
     )
     assert data[start:stop] == test_data
 

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -91,12 +91,11 @@ def test_modify_index_and_head_decompress(data, compressed_dfl_data):
     start = 0
     stop = 100
 
-    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop], False)
+    length = start - uncompressed_range[0]
+    offset = stop - start
     test_data = zran.decompress(
-        compressed_dfl_data[compressed_range[0] : compressed_range[1]],
-        new_index,
-        start - uncompressed_range[0],
-        stop - start,
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]], new_index, length, offset
     )
     assert data[start:stop] == test_data
 
@@ -108,11 +107,10 @@ def test_modify_index_and_interior_decompress(start_index, stop_index, data, com
     stop = index.points[stop_index].outloc + 100
 
     compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    length = start - uncompressed_range[0]
+    offset = stop - start
     test_data = zran.decompress(
-        compressed_dfl_data[compressed_range[0] : compressed_range[1]],
-        new_index,
-        start - uncompressed_range[0],
-        stop - start,
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]], new_index, length, offset
     )
     assert data[start:stop] == test_data
 
@@ -122,12 +120,11 @@ def test_modify_index_and_tail_decompress(data, compressed_dfl_data):
     start = index.points[-1].outloc + 100
     stop = len(data)
 
-    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop])
+    compressed_range, uncompressed_range, new_index = index.create_modified_index([start], [stop], False)
+    length = start - uncompressed_range[0]
+    offset = stop - start
     test_data = zran.decompress(
-        compressed_dfl_data[compressed_range[0] : compressed_range[1]],
-        new_index,
-        start - uncompressed_range[0],
-        stop - start,
+        compressed_dfl_data[compressed_range[0] : compressed_range[1]], new_index, length, offset
     )
     assert data[start:stop] == test_data
 
@@ -164,9 +161,10 @@ def test_modified_after_end_decompress(data, compressed_dfl_data):
             new_index.uncompressed_size,
         )
 
+
 @pytest.mark.skip(reason='Integration test. Only run if testing Sentinel-1 SLC burst compatibility')
 @pytest.mark.parametrize('burst', offset_list)
-def test_safe(burst, input_data):
+def test_burst_extraction(burst, input_data):
     swath, golden, index = input_data
     compressed_range, uncompressed_range, new_index = index.create_modified_index([burst.start], [burst.stop])
     data_subset = swath[compressed_range[0] : compressed_range[1]]


### PR DESCRIPTION
This PR adds two optimizations to reduce the file size of small modified indexes:

1. For cases when we have to add an additional point to overcome `point.bits != 0` issues, we set the window info to all zeros (since we will never use the data anyway) which allows it to be highly compressed.
2. The new default of `create_modified_index` is to remove the last stop point, since the final point represents the end of the data.

Additional testing was also added to make sure these change didn't add any unexpected behavior.

Compatibility with the [`index_safe`](https://github.com/forrestfwilliams/index_safe) has also been confirmed.