### PR TITLE
use bisection to find closest point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1]
+### Changed
+* Definition of `Point` class so that `__repr__` function does not need to be specified.
+* `get_closest_point` to use `bisect`, speeding up function.
+
+### Added
+* Comparison method to `Point` class to simplify sort implementation.
+
 ## [0.1.0]
 ### Fixed
 * Bug that would not allow you to create a valid modified index if the first point had a non-zero bits property

--- a/src/zran/zranlib.pyx
+++ b/src/zran/zranlib.pyx
@@ -1,7 +1,7 @@
 # vim: filetype=python
+import bisect
 import struct as py_struct
 import zlib
-import bisect
 from dataclasses import dataclass, field
 from functools import total_ordering
 from operator import attrgetter
@@ -62,7 +62,7 @@ class Point:
     bits: int
     window: bytes = field(repr=False)
 
-    def __lt__(self, other: Point) -> bool:
+    def __lt__(self, other: Point) -> bool:  # noqa: F821
         return self.outloc < other.outloc
 
 
@@ -190,7 +190,7 @@ def decompress(input_bytes: bytes, index: Index, offset: off_t, length: int) -> 
         A bytes object containing the decompressed data.
     """
     if offset + length > index.uncompressed_size:
-        raise ValueError('Offset and length specified would result in reading past the file bounds')
+        raise ValueError("Offset and length specified would result in reading past the file bounds")
 
     compressed_data = cython.declare(cython.p_char, PyBytes_AsString(input_bytes))
     compressed_data_length = cython.declare(off_t, PyBytes_Size(input_bytes))
@@ -270,7 +270,7 @@ class Index:
         window_data = []
         for i in range(have):
             loc_bytes = dflidx[header_length + (i * point_length) : header_length + ((i + 1) * point_length)]
-            loc_data.append(py_struct.unpack('<QQB', loc_bytes))
+            loc_data.append(py_struct.unpack("<QQB", loc_bytes))
 
             window_bytes = dflidx[point_end + (WINDOW_LENGTH * i) : point_end + (WINDOW_LENGTH * (i + 1))]
             window_data.append(window_bytes)

--- a/src/zran/zranlib.pyx
+++ b/src/zran/zranlib.pyx
@@ -1,7 +1,9 @@
 # vim: filetype=python
 import struct as py_struct
 import zlib
-from dataclasses import dataclass
+import bisect
+from dataclasses import dataclass, field
+from functools import total_ordering
 from operator import attrgetter
 from typing import Iterable, List, Optional
 
@@ -50,6 +52,7 @@ def check_for_error(return_code: int):
             raise ZranError(f"zran: failed with error code {return_code}")
 
 
+@total_ordering
 @dataclass(frozen=True)
 class Point:
     """A dataclass representing a point in a zran index."""
@@ -57,10 +60,10 @@ class Point:
     outloc: int
     inloc: int
     bits: int
-    window: bytes
+    window: bytes = field(repr=False)
 
-    def __repr__(self):
-        return f'Point(outloc={self.outloc}, inloc={self.inloc}, bits={self.bits})'
+    def __lt__(self, other: Point) -> bool:
+        return self.outloc < other.outloc
 
 
 @cython.cclass
@@ -342,15 +345,10 @@ def get_closest_point(points: Iterable[Point], value: int, greater_than: bool = 
     Returns:
         closest Point
     """
-    sorted_points = sorted(points, key=attrgetter("outloc"))
+    sorted_points = sorted(points)
+    closest = bisect.bisect(sorted_points, Point(value, 0, 0, b""))
 
-    closest = 0
-    for i in range(len(sorted_points)):
-        if sorted_points[i].outloc <= value and sorted_points[i].outloc > sorted_points[closest].outloc:
-            closest = i
-
-    if greater_than:
-        closest += 1
-        closest = min(closest, len(sorted_points) - 1)
+    if (not greater_than) or (closest == len(sorted_points)):
+        closest -= 1
 
     return sorted_points[closest]


### PR DESCRIPTION
This PR uses bisection in `get_closest_point`, to make better use of the points being sorted first.

In order to simplify the implementation, it also implements the comparison methods to order the Point instances directly without providing the `key` argument to sorted or bisect.