### PR TITLE
Add support for file objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `get_closest_point` to use `bisect`, speeding up function.
 
 ### Added
+* Support for file-like operations with `decompress` and `Index.create_index`.
 * Comparison method to `Point` class to simplify sort implementation.
 
 ## [0.1.0]

--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ To create and save the index:
 import zran
 
 with open('compressed.gz', 'rb') as f:
-    compressed_file = f.read()
-    index = zran.Index.create_index(compressed_file)
+    index = zran.Index.create_index(f)
 ```
 This `Index` can be written to a file (`index.to_file('index.dflidx')`), or directly passed to `zran.deompress`:
 ```python
 start = 1000
 length = 2000
-data = zran.decompress(compressed_file, index, start, length)
+
+with open(compressed_file, 'rb') as f:
+    data = zran.decompress(f, index, start, length)
 ```
 
 That's it!
@@ -57,4 +58,3 @@ If you prefer to work in the C programming language, you may want to work direct
 * Greater visibility into the contents of indexes
 * Compression of the indexes when written to a file, leading to smaller index file sizes
 * The ability to modify the points contained within an index via the `Index.create_modified_index()` method
-

--- a/src/zran/zranlib.pyx
+++ b/src/zran/zranlib.pyx
@@ -22,17 +22,6 @@ WINDOW_LENGTH = 32768
 GZ_WBITS = 31
 
 
-@cython.cfunc
-def coerce_to_posix_stream(input: Union[bytes, Any]) -> cython.pointer(FILE):
-    if isinstance(input, bytes):
-        compressed_data = cython.declare(cython.p_char, PyBytes_AsString(input))
-        compressed_data_length = cython.declare(off_t, PyBytes_Size(input))
-        fh = fmemopen(compressed_data, compressed_data_length, b"rb")
-    else:
-        fh = fdopen(dup(input.fileno()), b"rb")
-    return fh
-
-
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~Cython Functionality~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 class ZranError(Exception):
     pass
@@ -63,6 +52,17 @@ def check_for_error(return_code: int):
             raise ZranError("zran: failed with Z_STREAM_ERROR")
         else:
             raise ZranError(f"zran: failed with error code {return_code}")
+
+
+@cython.cfunc
+def coerce_to_posix_stream(input: Union[bytes, Any]) -> cython.pointer(FILE):
+    if isinstance(input, bytes):
+        compressed_data = cython.declare(cython.p_char, PyBytes_AsString(input))
+        compressed_data_length = cython.declare(off_t, PyBytes_Size(input))
+        fh = fmemopen(compressed_data, compressed_data_length, b"rb")
+    else:
+        fh = fdopen(dup(input.fileno()), b"rb")
+    return fh
 
 
 @total_ordering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import random
 import zlib
 
 import pytest
-
 import zran
 
 DFL_WBITS = -15
@@ -11,14 +10,14 @@ ZLIB_WBITS = 15
 GZ_WBITS = 31
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def input_data():
-    slc_name = 'tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
+    slc_name = "tests/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip"
     iw3_vv_start, iw3_vv_stop = (35813, 862111605)
     if not os.path.isfile(slc_name):
-        raise FileNotFoundError(f'{slc_name} must be present')
+        raise FileNotFoundError(f"{slc_name} must be present")
 
-    with open(slc_name, 'rb') as f:
+    with open(slc_name, "rb") as f:
         f.seek(iw3_vv_start)
         body = f.read(iw3_vv_stop - iw3_vv_start)
     index = zran.Index.create_index(body, span=2**20)
@@ -45,62 +44,92 @@ def create_compressed_data(uncompressed_data, wbits, start=None, stop=None):
     return compressed[start:stop]
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def gz_points():
     values = [
-        zran.Point(0, 1010, 0, b''),
-        zran.Point(200, 1110, 0, b''),
-        zran.Point(300, 1210, 0, b''),
-        zran.Point(400, 1310, 0, b''),
+        zran.Point(0, 1010, 0, b""),
+        zran.Point(200, 1110, 0, b""),
+        zran.Point(300, 1210, 0, b""),
+        zran.Point(400, 1310, 0, b""),
     ]
     return values
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def data():
     # Can't use os.random directly because there needs to be some
     # repitition in order for compression to be effective
     words = [os.urandom(8) for _ in range(1000)]
-    out = b''.join([random.choice(words) for _ in range(524288)])
+    out = b"".join([random.choice(words) for _ in range(524288)])
     return out
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def compressed_gz_data_no_head(data):
     compressed_data = create_compressed_data(data, GZ_WBITS, start=1562)
     yield compressed_data
     del compressed_data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def compressed_gz_data_no_tail(data):
     compressed_data = create_compressed_data(data, GZ_WBITS, stop=-1587)
     yield compressed_data
     del compressed_data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def compressed_gz_data(data):
     compressed_data = create_compressed_data(data, GZ_WBITS)
     yield compressed_data
     del compressed_data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def compressed_dfl_data(data):
     compressed_data = create_compressed_data(data, DFL_WBITS)
     yield compressed_data
     del compressed_data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="module")
 def compressed_zlib_data(data):
     compressed_data = create_compressed_data(data, ZLIB_WBITS)
     yield compressed_data
     del compressed_data
 
 
-@pytest.fixture(scope='function')
-def compressed_file(request, compressed_gz_data, compressed_dfl_data, compressed_zlib_data):
-    filenames = {'gz': compressed_gz_data, 'dfl': compressed_dfl_data, 'zlib': compressed_zlib_data}
+@pytest.fixture(scope="function")
+def compressed_data(request, compressed_gz_data, compressed_dfl_data, compressed_zlib_data):
+    filenames = {"gz": compressed_gz_data, "dfl": compressed_dfl_data, "zlib": compressed_zlib_data}
+    return filenames[request.param]
+
+
+@pytest.fixture(scope="function")
+def compressed_gz_file(compressed_gz_data, tmp_path):
+    file_path = tmp_path / "compressed.gz"
+    with open(file_path, "wb") as f:
+        f.write(compressed_gz_data)
+    return file_path
+
+
+@pytest.fixture(scope="function")
+def compressed_dfl_file(compressed_dfl_data, tmp_path):
+    file_path = tmp_path / "compressed.dfl"
+    with open(file_path, "wb") as f:
+        f.write(compressed_dfl_data)
+    return file_path
+
+
+@pytest.fixture(scope="function")
+def compressed_zlib_file(compressed_zlib_data, tmp_path):
+    file_path = tmp_path / "compressed.zlib"
+    with open(file_path, "wb") as f:
+        f.write(compressed_zlib_data)
+    return file_path
+
+
+@pytest.fixture(scope="function")
+def compressed_file(request, compressed_gz_file, compressed_dfl_file, compressed_zlib_file):
+    filenames = {"gz": compressed_gz_file, "dfl": compressed_dfl_file, "zlib": compressed_zlib_file}
     return filenames[request.param]

--- a/tests/test_zran.py
+++ b/tests/test_zran.py
@@ -2,14 +2,13 @@ import tempfile
 from collections import namedtuple
 
 import pytest
-
 import zran
 
 DFL_WBITS = -15
 ZLIB_WBITS = 15
 GZ_WBITS = 31
 
-Offset = namedtuple('Offset', ['start', 'stop'])
+Offset = namedtuple("Offset", ["start", "stop"])
 offset_list = [
     Offset(start=109395, stop=149033895),
     Offset(start=595807395, stop=744731895),
@@ -32,23 +31,39 @@ def test_create_index(compressed_gz_data):
     assert len(points[0].window) == 32768
 
 
+def test_create_index_from_file(compressed_gz_file, compressed_gz_data):
+    with open(compressed_gz_file, "rb") as f:
+        index = zran.Index.create_index(f)
+
+    assert index.mode == GZ_WBITS
+    assert index.uncompressed_size > 0
+    assert index.compressed_size == len(compressed_gz_data)
+    assert index.have == 4
+
+    points = index.points
+    assert points[0].outloc == 0
+    assert points[0].inloc == 10
+    assert points[0].bits == 0
+    assert len(points[0].window) == 32768
+
+
 # @pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
 def test_create_index_fail_head(data, compressed_gz_data_no_head):
-    with pytest.raises(zran.ZranError, match='zran: compressed data error in input file'):
+    with pytest.raises(zran.ZranError, match="zran: compressed data error in input file"):
         zran.Index.create_index(compressed_gz_data_no_head)
 
 
 # @pytest.mark.skip(reason='Currently unstable. Will sometimes not fail if data has certain (unknown) properties')
 def test_create_index_fail_tail(data, compressed_gz_data_no_tail):
-    with pytest.raises(zran.ZranError, match='zran: input file ended prematurely'):
+    with pytest.raises(zran.ZranError, match="zran: input file ended prematurely"):
         zran.Index.create_index(compressed_gz_data_no_tail)
 
 
-@pytest.mark.parametrize('compressed_file', ['gz', 'dfl', 'zlib'], indirect=True)
-def test_parse_index_file(compressed_file):
+@pytest.mark.parametrize("compressed_data", ["gz", "dfl", "zlib"], indirect=True)
+def test_parse_index_file(compressed_data):
     index_file = tempfile.NamedTemporaryFile()
 
-    index = zran.Index.create_index(compressed_file)
+    index = zran.Index.create_index(compressed_data)
     index.write_file(index_file.name)
     new_index = zran.Index.read_file(index_file.name)
 
@@ -59,12 +74,25 @@ def test_parse_index_file(compressed_file):
     assert len(index.points) == len(new_index.points)
 
 
-@pytest.mark.parametrize('compressed_file', ['gz', 'dfl', 'zlib'], indirect=True)
-def test_decompress(data, compressed_file):
+@pytest.mark.parametrize("compressed_data", ["gz", "dfl", "zlib"], indirect=True)
+def test_decompress(data, compressed_data):
     start = 100
     length = 1000
-    index = zran.Index.create_index(compressed_file)
-    test_data = zran.decompress(compressed_file, index, start, length)
+    index = zran.Index.create_index(compressed_data)
+    test_data = zran.decompress(compressed_data, index, start, length)
+    assert data[start : start + length] == test_data
+
+
+@pytest.mark.parametrize("compressed_file", ["gz", "dfl", "zlib"], indirect=True)
+def test_decompress_from_file(data, compressed_file):
+    start = 100
+    length = 1000
+    with open(compressed_file, "rb") as f:
+        index = zran.Index.create_index(f)
+
+    with open(compressed_file, "rb") as f:
+        test_data = zran.decompress(f, index, start, length)
+
     assert data[start : start + length] == test_data
 
 
@@ -73,12 +101,12 @@ def test_decompress_fail(data, compressed_gz_data, compressed_gz_data_no_head):
     start = 100
     length = 1000
     index = zran.Index.create_index(compressed_gz_data)
-    with pytest.raises(zran.ZranError, match='zran: compressed data error in input file'):
+    with pytest.raises(zran.ZranError, match="zran: compressed data error in input file"):
         zran.decompress(compressed_gz_data_no_head, index, start, length)
 
 
 def test_get_closest_point():
-    points = [zran.Point(0, 0, 0, b''), zran.Point(2, 0, 0, b''), zran.Point(4, 0, 0, b''), zran.Point(5, 0, 0, b'')]
+    points = [zran.Point(0, 0, 0, b""), zran.Point(2, 0, 0, b""), zran.Point(4, 0, 0, b""), zran.Point(5, 0, 0, b"")]
     r1 = zran.get_closest_point(points, 3)
     assert r1.outloc == 2
 
@@ -100,7 +128,7 @@ def test_modify_index_and_head_decompress(data, compressed_dfl_data):
     assert data[start:stop] == test_data
 
 
-@pytest.mark.parametrize('start_index,stop_index', ((0, 5), (4, 10), (9, -1)))
+@pytest.mark.parametrize("start_index,stop_index", ((0, 5), (4, 10), (9, -1)))
 def test_modify_index_and_interior_decompress(start_index, stop_index, data, compressed_dfl_data):
     index = zran.Index.create_index(compressed_dfl_data, span=2**18)
     start = index.points[start_index].outloc + 100
@@ -131,7 +159,7 @@ def test_modify_index_and_tail_decompress(data, compressed_dfl_data):
 
 def test_index_after_end_decompress(data, compressed_dfl_data):
     index = zran.Index.create_index(compressed_dfl_data, span=2**18)
-    with pytest.raises(ValueError, match='Offset and length specified would result in reading past the file bounds'):
+    with pytest.raises(ValueError, match="Offset and length specified would result in reading past the file bounds"):
         zran.decompress(compressed_dfl_data, index, 0, len(data) + 1)
 
 
@@ -141,7 +169,7 @@ def test_modified_after_end_decompress(data, compressed_dfl_data):
     stop = index.points[10].outloc
 
     compressed_range, uncompressed_range, new_index = index.create_modified_index([start], stop)
-    with pytest.raises(ValueError, match='Offset and length specified would result in reading past the file bounds'):
+    with pytest.raises(ValueError, match="Offset and length specified would result in reading past the file bounds"):
         zran.decompress(
             compressed_dfl_data[compressed_range[0] : compressed_range[1]],
             new_index,
@@ -159,7 +187,7 @@ def test_modified_nonzero_first_bits(data, compressed_dfl_data):
             nonfirst_zero_bit = True
 
     if not nonfirst_zero_bit:
-        print('Not enough index points to test this')
+        print("Not enough index points to test this")
 
     for point in index.points:
         start = point.outloc
@@ -175,8 +203,8 @@ def test_modified_nonzero_first_bits(data, compressed_dfl_data):
         assert true_data == test_data
 
 
-@pytest.mark.skip(reason='Integration test. Only run if testing Sentinel-1 SLC burst compatibility')
-@pytest.mark.parametrize('burst', offset_list)
+@pytest.mark.skip(reason="Integration test. Only run if testing Sentinel-1 SLC burst compatibility")
+@pytest.mark.parametrize("burst", offset_list)
 def test_burst_extraction(burst, input_data):
     swath, golden, index = input_data
     compressed_range, uncompressed_range, new_index = index.create_modified_index([burst.start], burst.stop)


### PR DESCRIPTION
`decompress` and `Index.create_index` are now able to take both bytes and file objects.